### PR TITLE
Update Chapter_03.R

### DIFF
--- a/Chapter 03/Chapter_03.R
+++ b/Chapter 03/Chapter_03.R
@@ -54,8 +54,10 @@ wbcd_test_labels <- wbcd[470:569, 1]
 # load the "class" library
 library(class)
 
-wbcd_test_pred <- knn(train = wbcd_train, test = wbcd_test,
-                      cl = wbcd_train_labels, k = 21)
+wbcd_test_pred <- knn(train = wbcd_train, 
+                      test = wbcd_test,
+                      cl = wbcd_train_labels$diagnosis, 
+                      k = 21)
 
 ## Step 4: Evaluating model performance ----
 


### PR DESCRIPTION
Code as provided results in an error: 

"> Error in knn(train = wbcd_train, test = wbcd_test, cl = wbcd_train_labels[, : 'train' and 'class' have different lengths"

Proposed solution cleans up that error.